### PR TITLE
Work with latest uap-core (Dec 17)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+uap-core/.travis.yml


### PR DESCRIPTION
Updated uap-csharp to work with latest uap-core which splits Windows family and version into the correct fields.