### PR TITLE
support for multiple .net frameworks in addition to netstandard, for …

### DIFF
--- a/UAParser/UAParser.csproj
+++ b/UAParser/UAParser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
+        <TargetFrameworks>net451;net452;net46;net461;net462;net47;net471;netstandard1.0;netstandard1.3</TargetFrameworks>
         <PackageId>UAParser</PackageId>
         <Authors>enemaerke</Authors>
         <Description>A .net wrapper for the ua-parser library</Description>
@@ -11,12 +11,12 @@
         <AssemblyName>UAParser</AssemblyName>
         <RootNamespace>UAParser</RootNamespace>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>3.0.0</Version>
+        <Version>3.1.0</Version>
         <PackageProjectUrl>https://github.com/ua-parser/uap-csharp</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/ua-parser/uap-csharp/blob/master/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/ua-parser/uap-csharp</RepositoryUrl>
-        <AssemblyVersion>3.0.0.0</AssemblyVersion>
-        <FileVersion>3.0.0.0</FileVersion>
+        <AssemblyVersion>3.1.0.0</AssemblyVersion>
+        <FileVersion>3.1.0.0</FileVersion>
         <Company />
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>../PublicKey.snk</AssemblyOriginatorKeyFile>
@@ -29,13 +29,13 @@
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <WarningsAsErrors />
-        <DocumentationFile>bin\Debug\netstandard1.0\UAParser.xml</DocumentationFile>
+        <DocumentationFile>bin\Debug\$(TargetFramework)\UAParser.xml</DocumentationFile>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <DocumentationFile>bin\Release\netstandard1.0\UAParser.xml</DocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <WarningsAsErrors />
+        <DocumentationFile>bin\Release\$(TargetFramework)\UAParser.xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
* added support for flavors of net framework which allows libraries not targetting netstandard to use uap-csharp. 

* bumped up the version from 3.0.0 to 3.1.0. 

* made sure that the .xml doc file is copied to each target framework folder.

NOTE - i assume if this PR is approved and merged, that a new nuget package for 3.1.0.0 will need to be pushed to the nuget.org repository.