### PR TITLE
Make build batch work with any VS 2017 edition

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe" build.proj /t:All
+call "%~dp0msbuild" build.proj /t:All

--- a/msbuild.cmd
+++ b/msbuild.cmd
@@ -1,0 +1,35 @@
+@echo off
+setlocal
+if "%PROCESSOR_ARCHITECTURE%"=="x86" set PROGRAMS=%ProgramFiles%
+if defined ProgramFiles(x86) set PROGRAMS=%ProgramFiles(x86)%
+for %%e in (Community Professional Enterprise) do (
+    if exist "%PROGRAMS%\Microsoft Visual Studio\2017\%%e\MSBuild\15.0\Bin\MSBuild.exe" (
+        set "MSBUILD=%PROGRAMS%\Microsoft Visual Studio\2017\%%e\MSBuild\15.0\Bin\MSBuild.exe"
+    )
+)
+if exist "%MSBUILD%" goto :build
+set MSBUILD=
+for %%i in (MSBuild.exe) do set MSBUILD=%%~dpnx$PATH:i
+if not defined MSBUILD goto :nomsbuild
+set MSBUILD_VERSION_MAJOR=
+set MSBUILD_VERSION_MINOR=
+for /f "delims=. tokens=1,2,3,4" %%m in ('msbuild /version /nologo') do (
+    set MSBUILD_VERSION_MAJOR=%%m
+    set MSBUILD_VERSION_MINOR=%%n
+)
+if not defined MSBUILD_VERSION_MAJOR goto :nomsbuild
+if not defined MSBUILD_VERSION_MINOR goto :nomsbuild
+if %MSBUILD_VERSION_MAJOR% lss 15    goto :nomsbuild
+if %MSBUILD_VERSION_MINOR% lss 1     goto :nomsbuild
+:build
+"%MSBUILD%" %*
+goto :EOF
+
+:nomsbuild
+echo>&2 Microsoft Build Engine 15.1 is required to build the solution. For
+echo>&2 installation instructions, see:
+echo>&2 https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio
+echo>&2 At the very least, you will want to install the MSBuilt Tool workload
+echo>&2 that has the identifier "Microsoft.VisualStudio.Workload.MSBuildTools":
+echo>&2 https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools#msbuild-tools
+exit /b s


### PR DESCRIPTION
`build.bat` always assumed Visual Studio 2017 Professional Edition. This PR fixes it so that it can work with any of the know editions.

Before applying the PR, running `build.bat` with a VS 2017 edition other than Professional would fail with:

```
> .\build.bat
>"C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe" build.proj /t:All
The system cannot find the path specified.
```
