### PR TITLE
Add .NET 2.0 target

### DIFF
--- a/UAParser/UAParser.cs
+++ b/UAParser/UAParser.cs
@@ -311,7 +311,11 @@ namespace UAParser
         /// <returns></returns>
         public static Parser GetDefault(ParserOptions parserOptions = null)
         {
-            using (var stream = typeof(Parser).GetTypeInfo().Assembly.GetManifestResourceStream("UAParser.regexes.yaml"))
+            using (var stream = typeof(Parser)
+#if INTROSPECTION_EXTENSIONS
+                                    .GetTypeInfo()
+#endif
+                                    .Assembly.GetManifestResourceStream("UAParser.regexes.yaml"))
             // ReSharper disable once AssignNullToNotNullAttribute
             using (var reader = new StreamReader(stream))
                 return new Parser(new MinimalYamlParser(reader.ReadToEnd()), parserOptions);

--- a/UAParser/UAParser.csproj
+++ b/UAParser/UAParser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net20</TargetFrameworks>
     <PackageId>UAParser</PackageId>
     <Authors>enemaerke</Authors>
     <Title>User Agent Parser for .Net</Title>
@@ -25,11 +25,19 @@
     <AssemblyOriginatorKeyFile>../PublicKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.0'">
+    <DefineConstants>INTROSPECTION_EXTENSIONS</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
-    <DefineConstants>REGEX_COMPILATION</DefineConstants>
+    <DefineConstants>REGEX_COMPILATION;INTROSPECTION_EXTENSIONS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
+    <DefineConstants>REGEX_COMPILATION;INTROSPECTION_EXTENSIONS</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net20'">
     <DefineConstants>REGEX_COMPILATION</DefineConstants>
   </PropertyGroup>
 
@@ -47,6 +55,12 @@
 
   <ItemGroup>
     <EmbeddedResource Include="..\uap-core\regexes.yaml" Link="regexes.yaml" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net20'">
+    <PackageReference Include="LinqBridge">
+      <Version>1.3.0</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR addresses issue #46.

It does not require any code changes since [LINQBridge](https://www.nuget.org/packages/LinqBridge/) provides all the missing features for .NET 2.0.