### PR TITLE
Add net45 framework as a target

### DIFF
--- a/UAParser/UAParser.csproj
+++ b/UAParser/UAParser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net20;netcoreapp2.0;net35;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net20;netcoreapp2.0;net35;net40;net45</TargetFrameworks>
     <PackageId>UAParser</PackageId>
     <Authors>enemaerke</Authors>
     <Title>User Agent Parser for .Net</Title>
@@ -51,6 +51,10 @@
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net40'">
     <DefineConstants>REGEX_COMPILATION</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
+    <DefineConstants>REGEX_COMPILATION;REGEX_MATCHTIMEOUT</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Problem: The new regex match timeout feature is enabled only for the
compatible framework. It appears in net45 but the latest net framework
in the project is net40. This means that this feature is not enabled for
all net framework.

Solution: Add net45 as a target framework and enable the feature for
this framework by defining a preprocessor symbol for this framework.

Issue: issues/55