### PR TITLE
Extract nested classes to separate files

### DIFF
--- a/UAParser.ConsoleApp/Program.cs
+++ b/UAParser.ConsoleApp/Program.cs
@@ -1,34 +1,34 @@
 namespace UAParser.ConsoleApp
 {
-  using System;
-  using System.Linq;
+    using System;
+    using System.Linq;
 
-  static class Program
-  {
-    static void Main(string[] args)
+    static class Program
     {
-      if (args.Any(arg => arg == "-?" || arg == "-h" || arg == "--help"))
-      {
-          Help();
-          return;
-      }
+        static void Main(string[] args)
+        {
+            if (args.Any(arg => arg == "-?" || arg == "-h" || arg == "--help"))
+            {
+                Help();
+                return;
+            }
 
-      var uaParser = Parser.GetDefault();
-      string uaString;
-      while ((uaString = Console.In.ReadLine()) != null)
-      {
-          uaString = uaString.Trim();
-          if (uaString.Length == 0)
-            continue;
-          var c = uaParser.Parse(uaString);
-          Console.WriteLine("Agent : {0}", c.UA);
-          Console.WriteLine("OS    : {0}", c.OS);
-          Console.WriteLine("Device: {0}", c.Device);
-      }
-    }
+            var uaParser = Parser.GetDefault();
+            string uaString;
+            while ((uaString = Console.In.ReadLine()) != null)
+            {
+                uaString = uaString.Trim();
+                if (uaString.Length == 0)
+                    continue;
+                var c = uaParser.Parse(uaString);
+                Console.WriteLine("Agent : {0}", c.UA);
+                Console.WriteLine("OS    : {0}", c.OS);
+                Console.WriteLine("Device: {0}", c.Device);
+            }
+        }
 
-    static void Help()
-    {
+        static void Help()
+        {
             Console.WriteLine(@"UAParser
 Copyright 2015 " + "S\u00f8ren Enem\u00e6rke" + @"
 https://github.com/tobie/ua-parser
@@ -36,6 +36,6 @@ https://github.com/tobie/ua-parser
 This application accepts user agent strings (one per line) from standard
 input, parses them and then emits the identified agent, operating system and
 device for each string.");
+        }
     }
-  }
 }

--- a/UAParser.Tests/DeviceYamlTestCase.cs
+++ b/UAParser.Tests/DeviceYamlTestCase.cs
@@ -2,94 +2,95 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using UAParser.Implementations;
 using Xunit;
 
 namespace UAParser.Tests
 {
-  public class DeviceYamlTestCase : YamlTestCase
-  {
-    public static DeviceYamlTestCase ReadFromMap(Dictionary<string, string> map)
+    public class DeviceYamlTestCase : YamlTestCase
     {
-      DeviceYamlTestCase tc = new DeviceYamlTestCase()
-      {
-        UserAgent = map["user_agent_string"],
-        Family = map["family"],
+        public static DeviceYamlTestCase ReadFromMap(Dictionary<string, string> map)
+        {
+            DeviceYamlTestCase tc = new DeviceYamlTestCase()
+            {
+                UserAgent = map["user_agent_string"],
+                Family = map["family"],
 
-      };
-      return tc;
+            };
+            return tc;
+        }
+
+        public string Family { get; set; }
+
+        public override void Verify(ClientInfo clientInfo)
+        {
+            Assert.NotNull(clientInfo);
+            AssertMatch(Family, clientInfo.Device.Family, "Family");
+        }
     }
 
-    public string Family { get; set; }
-
-    public override void Verify(ClientInfo clientInfo)
+    public class OSYamlTestCase : YamlTestCase
     {
-      Assert.NotNull(clientInfo);
-      AssertMatch(Family,clientInfo.Device.Family,"Family");
-    }
-  }
+        public static OSYamlTestCase ReadFromMap(Dictionary<string, string> map)
+        {
+            OSYamlTestCase tc = new OSYamlTestCase()
+            {
+                UserAgent = map["user_agent_string"],
+                Family = map["family"],
+                Major = map["major"],
+                Minor = map["minor"],
+                Patch = map["patch"],
+                PatchMinor = map["patch_minor"]
+            };
+            return tc;
+        }
 
-  public class OSYamlTestCase : YamlTestCase
-  {
-    public static OSYamlTestCase ReadFromMap(Dictionary<string, string> map)
-    {
-      OSYamlTestCase tc = new OSYamlTestCase()
-      {
-        UserAgent = map["user_agent_string"],
-        Family = map["family"],
-        Major = map["major"],
-        Minor = map["minor"],
-        Patch = map["patch"],
-        PatchMinor = map["patch_minor"]
-      };
-      return tc;
-    }
+        public string Family { get; set; }
+        public string Major { get; set; }
+        public string Minor { get; set; }
+        public string Patch { get; set; }
+        public string PatchMinor { get; set; }
 
-    public string Family { get; set; }
-    public string Major { get; set; }
-    public string Minor { get; set; }
-    public string Patch { get; set; }
-    public string PatchMinor { get; set; }
+        public override void Verify(ClientInfo clientInfo)
+        {
+            Assert.NotNull(clientInfo);
+            AssertMatch(Family, clientInfo.OS.Family, "Family");
+            AssertMatch(Major, clientInfo.OS.Major, "Major");
+            AssertMatch(Minor, clientInfo.OS.Minor, "Minor");
+            AssertMatch(Patch, clientInfo.OS.Patch, "Patch");
+            AssertMatch(PatchMinor, clientInfo.OS.PatchMinor, "PatchMinor");
 
-    public override void Verify(ClientInfo clientInfo)
-    {
-      Assert.NotNull(clientInfo);
-      AssertMatch(Family, clientInfo.OS.Family, "Family");
-      AssertMatch(Major, clientInfo.OS.Major, "Major");
-      AssertMatch(Minor, clientInfo.OS.Minor, "Minor");
-      AssertMatch(Patch, clientInfo.OS.Patch, "Patch");
-      AssertMatch(PatchMinor, clientInfo.OS.PatchMinor, "PatchMinor");
-
-    }
-  }
-
-  public class UserAgentYamlTestCase : YamlTestCase
-  {
-    public static UserAgentYamlTestCase ReadFromMap(Dictionary<string, string> map)
-    {
-      UserAgentYamlTestCase tc = new UserAgentYamlTestCase()
-      {
-        UserAgent = map["user_agent_string"],
-        Family = map["family"],
-        Major = map["major"],
-        Minor = map["minor"],
-        Patch = map["patch"],
-      };
-      return tc;
+        }
     }
 
-    public string Family { get; set; }
-    public string Major { get; set; }
-    public string Minor { get; set; }
-    public string Patch { get; set; }
-
-    public override void Verify(ClientInfo clientInfo)
+    public class UserAgentYamlTestCase : YamlTestCase
     {
-      Assert.NotNull(clientInfo);
-      AssertMatch(Family, clientInfo.UA.Family, "Family");
-      AssertMatch(Major, clientInfo.UA.Major, "Major");
-      AssertMatch(Minor, clientInfo.UA.Minor, "Minor");
-      AssertMatch(Patch, clientInfo.UA.Patch, "Patch");
+        public static UserAgentYamlTestCase ReadFromMap(Dictionary<string, string> map)
+        {
+            UserAgentYamlTestCase tc = new UserAgentYamlTestCase()
+            {
+                UserAgent = map["user_agent_string"],
+                Family = map["family"],
+                Major = map["major"],
+                Minor = map["minor"],
+                Patch = map["patch"],
+            };
+            return tc;
+        }
 
+        public string Family { get; set; }
+        public string Major { get; set; }
+        public string Minor { get; set; }
+        public string Patch { get; set; }
+
+        public override void Verify(ClientInfo clientInfo)
+        {
+            Assert.NotNull(clientInfo);
+            AssertMatch(Family, clientInfo.UA.Family, "Family");
+            AssertMatch(Major, clientInfo.UA.Major, "Major");
+            AssertMatch(Minor, clientInfo.UA.Minor, "Minor");
+            AssertMatch(Patch, clientInfo.UA.Patch, "Patch");
+
+        }
     }
-  }
 }

--- a/UAParser.Tests/InternalExtensions.cs
+++ b/UAParser.Tests/InternalExtensions.cs
@@ -20,12 +20,12 @@ namespace UAParser.Tests
         }
         internal static Dictionary<string, string> ConvertToDictionary(this YamlMappingNode yamlNode)
         {
-          Dictionary<string, string> dic = new Dictionary<string, string>();
-          foreach (var key in yamlNode.Children.Keys)
-          {
-            dic[key.ToString()] = yamlNode.Children[key].ToString();
-          }
-          return dic;
+            Dictionary<string, string> dic = new Dictionary<string, string>();
+            foreach (var key in yamlNode.Children.Keys)
+            {
+                dic[key.ToString()] = yamlNode.Children[key].ToString();
+            }
+            return dic;
         }
         internal static string GetTestResources(this object self, string name)
         {

--- a/UAParser.Tests/TestResourceTests.cs
+++ b/UAParser.Tests/TestResourceTests.cs
@@ -106,7 +106,7 @@ namespace UAParser.Tests
               .Select(configMap =>
               {
                   if (!configMap.ContainsKey("js_ua")) //we deliberately skip tests with js-user agents
-                return testCaseFunction(configMap);
+                      return testCaseFunction(configMap);
                   return default(TTestCase);
               })
               .ToList();

--- a/UAParser.Tests/YamlParsing.cs
+++ b/UAParser.Tests/YamlParsing.cs
@@ -43,15 +43,15 @@ namespace UAParser.Tests
             {
                 var configNode = kvPair.Value;
                 var valueDic = from node in configNode ?? Enumerable.Empty<YamlNode>()
-                    select node as YamlMappingNode
+                               select node as YamlMappingNode
                     into node
-                    where node != null
-                    select node.Children
-                        .Where(e => e.Key is YamlScalarNode && e.Value is YamlScalarNode)
-                        .GroupBy(e => e.Key.ToString(), e => e.Value.ToString(), StringComparer.OrdinalIgnoreCase)
-                        .ToDictionary(e => e.Key, e => e.Last(), StringComparer.OrdinalIgnoreCase)
+                               where node != null
+                               select node.Children
+                                   .Where(e => e.Key is YamlScalarNode && e.Value is YamlScalarNode)
+                                   .GroupBy(e => e.Key.ToString(), e => e.Value.ToString(), StringComparer.OrdinalIgnoreCase)
+                                   .ToDictionary(e => e.Key, e => e.Last(), StringComparer.OrdinalIgnoreCase)
                     into cm
-                    select cm;
+                               select cm;
 
                 string name = kvPair.Key;
                 var minimalLookupList = minimal.ReadMapping(name).ToList();

--- a/UAParser.Tests/YamlTestCase.cs
+++ b/UAParser.Tests/YamlTestCase.cs
@@ -2,27 +2,28 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using UAParser.Implementations;
 using Xunit;
 
 namespace UAParser.Tests
 {
-  public abstract class YamlTestCase
-  {
-    public string UserAgent { get; set; }
-    public abstract void Verify(ClientInfo clientInfo);
-
-    protected void AssertMatch<T>(T expected, T actual, string type)
+    public abstract class YamlTestCase
     {
-      if (typeof(T) == typeof(string))
-      {
-        string exp = expected as string;
-        string act = actual as string;
+        public string UserAgent { get; set; }
+        public abstract void Verify(ClientInfo clientInfo);
 
-        if (string.IsNullOrEmpty(exp) && string.IsNullOrEmpty(act))
-          return;
-      }
+        protected void AssertMatch<T>(T expected, T actual, string type)
+        {
+            if (typeof(T) == typeof(string))
+            {
+                string exp = expected as string;
+                string act = actual as string;
 
-      Assert.True(expected.Equals(actual), type+" did not match. (expected:" + expected + " actual:" + actual + ")  in " + UserAgent);
+                if (string.IsNullOrEmpty(exp) && string.IsNullOrEmpty(act))
+                    return;
+            }
+
+            Assert.True(expected.Equals(actual), type + " did not match. (expected:" + expected + " actual:" + actual + ")  in " + UserAgent);
+        }
     }
-  }
 }

--- a/UAParser/Abstractions/IUAParserOutput.cs
+++ b/UAParser/Abstractions/IUAParserOutput.cs
@@ -1,0 +1,50 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser.Abstractions
+{
+    /// <summary>
+    /// Representing the parse results. Structure of this class aligns with the
+    /// ua-parser-output WebIDL structure defined in this document: https://github.com/ua-parser/uap-core/blob/master/docs/specification.md
+    /// </summary>
+    public interface IUAParserOutput
+    {
+        /// <summary>
+        /// The user agent string, the input for the UAParser
+        /// </summary>
+        string String { get; }
+
+        /// <summary>
+        /// The OS parsed from the user agent string
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        OS OS { get; }
+        /// <summary>
+        /// The Device parsed from the user agent string
+        /// </summary>
+        Device Device { get; }
+        // ReSharper disable once InconsistentNaming
+        /// <summary>
+        /// The User Agent parsed from the user agent string
+        /// </summary>
+        UserAgent UA { get; }
+    }
+
+}

--- a/UAParser/Device.cs
+++ b/UAParser/Device.cs
@@ -1,0 +1,69 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser
+{
+    using System;
+
+    /// <summary>
+    /// Represents the physical device the user agent is using
+    /// </summary>
+    public sealed class Device
+    {
+        /// <summary>
+        /// Constructs a Device instance
+        /// </summary>
+        public Device(string family, string brand, string model)
+        {
+            Family = family.Trim();
+            if (brand != null)
+                Brand = brand.Trim();
+            if (model != null)
+                Model = model.Trim();
+        }
+
+        /// <summary>
+        /// Returns true if the device is likely to be a spider or a bot device
+        /// </summary>
+        public bool IsSpider => "Spider".Equals(Family, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        ///The brand of the device
+        /// </summary>
+        public string Brand { get; }
+        /// <summary>
+        /// The family of the device, if available
+        /// </summary>
+        public string Family { get; }
+        /// <summary>
+        /// The model of the device, if available
+        /// </summary>
+        public string Model { get; }
+
+        /// <summary>
+        /// A readable description of the device
+        /// </summary>
+        public override string ToString()
+        {
+            return Family;
+        }
+    }
+
+}

--- a/UAParser/Extensions/DictionaryExtensions.cs
+++ b/UAParser/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,35 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    internal static class DictionaryExtensions
+    {
+        public static TValue Find<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            if (dictionary == null) throw new ArgumentNullException(nameof(dictionary));
+            return dictionary.TryGetValue(key, out var result) ? result : default;
+        }
+    }
+
+}

--- a/UAParser/Extensions/StringExtensions.cs
+++ b/UAParser/Extensions/StringExtensions.cs
@@ -1,0 +1,37 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser.Extensions
+{
+    using System;
+
+    internal static class StringExtensions
+    {
+        public static string ReplaceFirstOccurence(this string input, string search, string replacement)
+        {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+            var index = input.IndexOf(search, StringComparison.Ordinal);
+            return index >= 0
+                 ? input.Substring(0, index) + replacement + input.Substring(index + search.Length)
+                 : input;
+        }
+    }
+
+}

--- a/UAParser/Implementations/ClientInfo.cs
+++ b/UAParser/Implementations/ClientInfo.cs
@@ -1,0 +1,80 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser.Implementations
+{
+    using System;
+    using UAParser.Abstractions;
+
+    /// <summary>
+    /// Represents the user agent client information resulting from parsing
+    /// a user agent string
+    /// </summary>
+    public class ClientInfo : IUAParserOutput
+    {
+        /// <summary>
+        /// The user agent string, the input for the UAParser
+        /// </summary>
+        public string String { get; }
+        // ReSharper disable once InconsistentNaming
+        /// <summary>
+        /// The OS parsed from the user agent string
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        public OS OS { get; }
+
+        /// <summary>
+        /// The Device parsed from the user agent string
+        /// </summary>
+        public Device Device { get; }
+        /// <summary>
+        /// The User Agent parsed from the user agent string
+        /// </summary>
+        [Obsolete("Mirrors the value of the UA property. Will be removed in future versions")]
+        public UserAgent UserAgent => UA;
+
+        // ReSharper disable once InconsistentNaming
+        /// <summary>
+        /// The User Agent parsed from the user agent string
+        /// </summary>
+        public UserAgent UA { get; }
+
+        /// <summary>
+        /// Constructs an instance of the ClientInfo with results of the user agent string parsing
+        /// </summary>
+        public ClientInfo(string inputString, OS os, Device device, UserAgent userAgent)
+        {
+            String = inputString;
+            OS = os;
+            Device = device;
+            UA = userAgent;
+        }
+
+        /// <summary>
+        /// A readable description of the user agent client information
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return $"{OS} {Device} {UA}";
+        }
+    }
+
+}

--- a/UAParser/MinimalYamlParser.cs
+++ b/UAParser/MinimalYamlParser.cs
@@ -1,0 +1,135 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Just enough string parsing to recognize the regexes.yaml file format. Introduced to remove
+    /// dependency on large Yaml parsing lib. Note that a unittest ensures compatibility
+    /// by ensuring regexes and properties are read similar to using the full yaml lib
+    /// </summary>
+    internal class MinimalYamlParser
+    {
+        internal class Mapping
+        {
+            private Dictionary<string, string> _lastEntry;
+
+            public Mapping()
+            {
+                Sequences = new List<Dictionary<string, string>>();
+            }
+
+            public List<Dictionary<string, string>> Sequences { get; }
+
+            public void BeginSequence()
+            {
+                _lastEntry = new Dictionary<string, string>();
+                Sequences.Add(_lastEntry);
+            }
+
+            public void AddToSequence(string key, string value)
+            {
+                _lastEntry[key] = value;
+            }
+        }
+
+        private readonly Dictionary<string, Mapping> _mappings = new Dictionary<string, Mapping>();
+
+        public MinimalYamlParser(string yamlString)
+        {
+            ReadIntoMappingModel(yamlString);
+        }
+
+        internal IDictionary<string, Mapping> Mappings => _mappings;
+
+        private void ReadIntoMappingModel(string yamlInputString)
+        {
+            // line splitting using various splitting characters
+            string[] lines = yamlInputString.Split(new[] { Environment.NewLine, "\r", "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+            int lineCount = 0;
+            Mapping activeMapping = null;
+
+            foreach (var line in lines)
+            {
+                lineCount++;
+                if (line.Trim().StartsWith("#")) //skipping comments
+                    continue;
+                if (line.Trim().Length == 0)
+                    continue;
+
+                //is this a new mapping entity
+                if (line[0] != ' ')
+                {
+                    int indexOfMappingColon = line.IndexOf(':');
+                    if (indexOfMappingColon == -1)
+                        throw new ArgumentException("YamlParsing: Expecting mapping entry to contain a ':', at line " + lineCount);
+                    string name = line.Substring(0, indexOfMappingColon).Trim();
+                    activeMapping = new Mapping();
+                    _mappings.Add(name, activeMapping);
+                    continue;
+                }
+
+                //reading scalar entries into the active mapping
+                if (activeMapping == null)
+                    throw new ArgumentException("YamlParsing: Expecting mapping entry to contain a ':', at line " + lineCount);
+
+                var seqLine = line.Trim();
+                if (seqLine[0] == '-')
+                {
+                    activeMapping.BeginSequence();
+                    seqLine = seqLine.Substring(1);
+                }
+
+                int indexOfColon = seqLine.IndexOf(':');
+                if (indexOfColon == -1)
+                    throw new ArgumentException("YamlParsing: Expecting scalar mapping entry to contain a ':', at line " + lineCount);
+
+                string key = seqLine.Substring(0, indexOfColon).Trim();
+                string value = ReadQuotedValue(seqLine.Substring(indexOfColon + 1).Trim());
+                activeMapping.AddToSequence(key, value);
+            }
+        }
+
+        private static string ReadQuotedValue(string value)
+        {
+            if (value.StartsWith("'") && value.EndsWith("'"))
+                return value.Substring(1, value.Length - 2);
+            if (value.StartsWith("\"") && value.EndsWith("\""))
+                return value.Substring(1, value.Length - 2);
+            return value;
+        }
+
+        public IEnumerable<Dictionary<string, string>> ReadMapping(string mappingName)
+        {
+            if (_mappings.TryGetValue(mappingName, out var mapping))
+            {
+                foreach (var s in mapping.Sequences)
+                {
+                    var temp = s;
+                    yield return temp;
+                }
+            }
+        }
+    }
+
+}

--- a/UAParser/OS.cs
+++ b/UAParser/OS.cs
@@ -1,0 +1,72 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser
+{
+    /// <summary>
+    /// Represents the operating system the user agent runs on
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public sealed class OS
+    {
+        /// <summary>
+        /// Constructs an OS instance
+        /// </summary>
+        public OS(string family, string major, string minor, string patch, string patchMinor)
+        {
+            Family = family;
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+            PatchMinor = patchMinor;
+        }
+
+        /// <summary>
+        /// The familiy of the OS
+        /// </summary>
+        public string Family { get; }
+        /// <summary>
+        /// The major version of the OS, if available
+        /// </summary>
+        public string Major { get; }
+        /// <summary>
+        /// The minor version of the OS, if available
+        /// </summary>
+        public string Minor { get; }
+        /// <summary>
+        /// The patch version of the OS, if available
+        /// </summary>
+        public string Patch { get; }
+        /// <summary>
+        /// The minor patch version of the OS, if available
+        /// </summary>
+        public string PatchMinor { get; }
+        /// <summary>
+        /// A readable description of the OS
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var version = VersionString.Format(Major, Minor, Patch, PatchMinor);
+            return Family + (!string.IsNullOrEmpty(version) ? " " + version : null);
+        }
+    }
+
+}

--- a/UAParser/ParserOptions.cs
+++ b/UAParser/ParserOptions.cs
@@ -1,0 +1,49 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser
+{
+    using System;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Options available for the parser
+    /// </summary>
+    public sealed class ParserOptions
+    {
+#if REGEX_COMPILATION
+        /// <summary>
+        /// If true, will use compiled regular expressions for slower startup time
+        /// but higher throughput. The default is false.
+        /// </summary>
+        public bool UseCompiledRegex { get; set; }
+#endif
+
+#if REGEX_MATCHTIMEOUT
+        /// <summary>
+        /// Allows for specifying the maximum time spent on regular expressions,
+        /// serving as a fail safe for potential infinite backtracking. The default is
+        /// set to Regex.InfiniteMatchTimeout
+        /// </summary>
+        public TimeSpan MatchTimeOut { get; set; } = Regex.InfiniteMatchTimeout;
+#endif
+    }
+
+}

--- a/UAParser/RegexBinderBuilder.cs
+++ b/UAParser/RegexBinderBuilder.cs
@@ -1,0 +1,44 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.RegularExpressions;
+
+    internal static class RegexBinderBuilder
+    {
+        public static Func<Match, IEnumerator<int>, TResult> SelectMany<T1, T2, TResult>(
+            this Func<Match, IEnumerator<int>, T1> binder,
+            Func<T1, Func<Match, IEnumerator<int>, T2>> continuation,
+            Func<T1, T2, TResult> projection)
+        {
+            return (m, num) =>
+            {
+                T1 bound = binder(m, num);
+                T2 continued = continuation(bound)(m, num);
+                TResult projected = projection(bound, continued);
+                return projected;
+            };
+        }
+    }
+
+}

--- a/UAParser/UAParser.cs
+++ b/UAParser/UAParser.cs
@@ -26,255 +26,8 @@ namespace UAParser
     using System.IO;
     using System.Linq;
     using System.Text.RegularExpressions;
-
-    /// <summary>
-    /// Represents the physical device the user agent is using
-    /// </summary>
-    public sealed class Device
-    {
-        /// <summary>
-        /// Constructs a Device instance
-        /// </summary>
-        public Device(string family, string brand, string model)
-        {
-            Family = family.Trim();
-            if (brand != null)
-                Brand = brand.Trim();
-            if (model != null)
-                Model = model.Trim();
-        }
-
-        /// <summary>
-        /// Returns true if the device is likely to be a spider or a bot device
-        /// </summary>
-        public bool IsSpider => "Spider".Equals(Family, StringComparison.OrdinalIgnoreCase);
-
-        /// <summary>
-        ///The brand of the device
-        /// </summary>
-        public string Brand { get; }
-        /// <summary>
-        /// The family of the device, if available
-        /// </summary>
-        public string Family { get; }
-        /// <summary>
-        /// The model of the device, if available
-        /// </summary>
-        public string Model { get; }
-
-        /// <summary>
-        /// A readable description of the device
-        /// </summary>
-        public override string ToString()
-        {
-            return Family;
-        }
-    }
-
-    /// <summary>
-    /// Represents the operating system the user agent runs on
-    /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public sealed class OS
-    {
-        /// <summary>
-        /// Constructs an OS instance
-        /// </summary>
-        public OS(string family, string major, string minor, string patch, string patchMinor)
-        {
-            Family     = family;
-            Major      = major;
-            Minor      = minor;
-            Patch      = patch;
-            PatchMinor = patchMinor;
-        }
-
-        /// <summary>
-        /// The familiy of the OS
-        /// </summary>
-        public string Family     { get; }
-        /// <summary>
-        /// The major version of the OS, if available
-        /// </summary>
-        public string Major      { get; }
-        /// <summary>
-        /// The minor version of the OS, if available
-        /// </summary>
-        public string Minor      { get; }
-        /// <summary>
-        /// The patch version of the OS, if available
-        /// </summary>
-        public string Patch      { get; }
-        /// <summary>
-        /// The minor patch version of the OS, if available
-        /// </summary>
-        public string PatchMinor { get; }
-        /// <summary>
-        /// A readable description of the OS
-        /// </summary>
-        /// <returns></returns>
-        public override string ToString()
-        {
-            var version = VersionString.Format(Major, Minor, Patch, PatchMinor);
-            return Family + (!string.IsNullOrEmpty(version) ? " " + version : null);
-        }
-    }
-
-    /// <summary>
-    /// Represents a user agent, commonly a browser
-    /// </summary>
-    public sealed class UserAgent
-    {
-        /// <summary>
-        /// Construct a UserAgent instance
-        /// </summary>
-        public UserAgent(string family, string major, string minor, string patch)
-        {
-            Family = family;
-            Major  = major;
-            Minor  = minor;
-            Patch  = patch;
-        }
-
-        /// <summary>
-        /// The family of user agent
-        /// </summary>
-        public string Family { get; }
-        /// <summary>
-        /// Major version of the user agent, if available
-        /// </summary>
-        public string Major  { get; }
-        /// <summary>
-        /// Minor version of the user agent, if available
-        /// </summary>
-        public string Minor  { get; }
-        /// <summary>
-        /// Patch version of the user agent, if available
-        /// </summary>
-        public string Patch  { get; }
-
-        /// <summary>
-        /// The user agent as a readbale string
-        /// </summary>
-        /// <returns></returns>
-        public override string ToString()
-        {
-            var version = VersionString.Format(Major, Minor, Patch);
-            return Family + (!string.IsNullOrEmpty(version) ? " " + version : null);
-        }
-    }
-
-    internal static class VersionString
-    {
-        public static string Format(params string[] parts)
-        {
-            return string.Join(".", parts.Where(v => !String.IsNullOrEmpty(v)).ToArray());
-        }
-    }
-
-    /// <summary>
-    /// Representing the parse results. Structure of this class aligns with the
-    /// ua-parser-output WebIDL structure defined in this document: https://github.com/ua-parser/uap-core/blob/master/docs/specification.md
-    /// </summary>
-    public interface IUAParserOutput
-    {
-        /// <summary>
-        /// The user agent string, the input for the UAParser
-        /// </summary>
-        string String { get; }
-
-        /// <summary>
-        /// The OS parsed from the user agent string
-        /// </summary>
-        // ReSharper disable once InconsistentNaming
-        OS OS { get; }
-        /// <summary>
-        /// The Device parsed from the user agent string
-        /// </summary>
-        Device Device { get; }
-        // ReSharper disable once InconsistentNaming
-        /// <summary>
-        /// The User Agent parsed from the user agent string
-        /// </summary>
-        UserAgent UA { get; }
-    }
-
-    /// <summary>
-    /// Represents the user agent client information resulting from parsing
-    /// a user agent string
-    /// </summary>
-    public class ClientInfo : IUAParserOutput
-    {
-        /// <summary>
-        /// The user agent string, the input for the UAParser
-        /// </summary>
-        public string String { get; }
-        // ReSharper disable once InconsistentNaming
-        /// <summary>
-        /// The OS parsed from the user agent string
-        /// </summary>
-        // ReSharper disable once InconsistentNaming
-        public OS OS { get; }
-
-        /// <summary>
-        /// The Device parsed from the user agent string
-        /// </summary>
-        public Device Device { get; }
-        /// <summary>
-        /// The User Agent parsed from the user agent string
-        /// </summary>
-        [Obsolete("Mirrors the value of the UA property. Will be removed in future versions")]
-        public UserAgent UserAgent => UA;
-
-        // ReSharper disable once InconsistentNaming
-        /// <summary>
-        /// The User Agent parsed from the user agent string
-        /// </summary>
-        public UserAgent UA { get; }
-
-        /// <summary>
-        /// Constructs an instance of the ClientInfo with results of the user agent string parsing
-        /// </summary>
-        public ClientInfo(string inputString, OS os, Device device, UserAgent userAgent)
-        {
-            String = inputString;
-            OS = os;
-            Device = device;
-            UA = userAgent;
-        }
-
-        /// <summary>
-        /// A readable description of the user agent client information
-        /// </summary>
-        /// <returns></returns>
-        public override string ToString()
-        {
-            return $"{OS} {Device} {UA}";
-        }
-    }
-
-    /// <summary>
-    /// Options available for the parser
-    /// </summary>
-    public sealed class ParserOptions
-    {
-#if REGEX_COMPILATION
-        /// <summary>
-        /// If true, will use compiled regular expressions for slower startup time
-        /// but higher throughput. The default is false.
-        /// </summary>
-        public bool UseCompiledRegex { get; set; }
-#endif
-
-#if REGEX_MATCHTIMEOUT
-        /// <summary>
-        /// Allows for specifying the maximum time spent on regular expressions,
-        /// serving as a fail safe for potential infinite backtracking. The default is
-        /// set to Regex.InfiniteMatchTimeout
-        /// </summary>
-        public TimeSpan MatchTimeOut { get; set; } = Regex.InfiniteMatchTimeout;
-#endif
-    }
+    using UAParser.Extensions;
+    using UAParser.Implementations;
 
     /// <summary>
     /// Represents a parser of a user agent string
@@ -339,9 +92,9 @@ namespace UAParser
         /// </summary>
         public ClientInfo Parse(string uaString)
         {
-            var os     = ParseOS(uaString);
+            var os = ParseOS(uaString);
             var device = ParseDevice(uaString);
-            var ua     = ParseUserAgent(uaString);
+            var ua = ParseUserAgent(uaString);
             return new ClientInfo(uaString, os, device, ua);
         }
 
@@ -460,19 +213,19 @@ namespace UAParser
                     if (v2Replacement == "$2")
                     {
                         return Create(regex, from v1 in Replace(v1Replacement, "$1")
-                            from v2 in Replace(v2Replacement, "$2")
-                            from v3 in Replace(v3Replacement, "$3")
-                            from v4 in Replace(v4Replacement, "$4")
-                            from family in Replace(osReplacement, "$5")
-                            select new OS(family, v1, v2, v3, v4));
+                                             from v2 in Replace(v2Replacement, "$2")
+                                             from v3 in Replace(v3Replacement, "$3")
+                                             from v4 in Replace(v4Replacement, "$4")
+                                             from family in Replace(osReplacement, "$5")
+                                             select new OS(family, v1, v2, v3, v4));
                     }
 
                     return Create(regex, from v1 in Replace(v1Replacement, "$1")
-                        from family in Replace(osReplacement, "$2")
-                        from v2 in Replace(v2Replacement, "$3")
-                        from v3 in Replace(v3Replacement, "$4")
-                        from v4 in Replace(v4Replacement, "$5")
-                        select new OS(family, v1, v2, v3, v4));
+                                         from family in Replace(osReplacement, "$2")
+                                         from v2 in Replace(v2Replacement, "$3")
+                                         from v3 in Replace(v3Replacement, "$4")
+                                         from v4 in Replace(v4Replacement, "$5")
+                                         select new OS(family, v1, v2, v3, v4));
                 }
 
                 return Create(regex, from family in Replace(osReplacement, "$1")
@@ -594,7 +347,7 @@ namespace UAParser
                     var num = Generate(1, n => n + 1);
                     return m.Success ? binder(m, num) : default(T);
 #endif
-                    };
+                };
             }
 
             private static IEnumerator<T> Generate<T>(T initial, Func<T, T> next)
@@ -605,152 +358,4 @@ namespace UAParser
             }
         }
     }
-
-    internal static class RegexBinderBuilder
-    {
-        public static Func<Match, IEnumerator<int>, TResult> SelectMany<T1, T2, TResult>(
-            this Func<Match, IEnumerator<int>, T1> binder,
-            Func<T1, Func<Match, IEnumerator<int>, T2>> continuation,
-            Func<T1, T2, TResult> projection)
-        {
-            return (m, num) =>
-            {
-                T1 bound = binder(m, num);
-                T2 continued = continuation(bound)(m, num);
-                TResult projected = projection(bound, continued);
-                return projected;
-            };
-        }
-    }
-
-    internal static class StringExtensions
-    {
-        public static string ReplaceFirstOccurence(this string input, string search, string replacement)
-        {
-            if (input == null) throw new ArgumentNullException(nameof(input));
-            var index = input.IndexOf(search, StringComparison.Ordinal);
-            return index >= 0
-                 ? input.Substring(0, index) + replacement + input.Substring(index + search.Length)
-                 : input;
-        }
-    }
-
-    internal static class DictionaryExtensions
-    {
-        public static TValue Find<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
-        {
-            if (dictionary == null) throw new ArgumentNullException(nameof(dictionary));
-            return dictionary.TryGetValue(key, out var result) ? result : default(TValue);
-        }
-    }
-
-    /// <summary>
-    /// Just enough string parsing to recognize the regexes.yaml file format. Introduced to remove
-    /// dependency on large Yaml parsing lib. Note that a unittest ensures compatibility
-    /// by ensuring regexes and properties are read similar to using the full yaml lib
-    /// </summary>
-    internal class MinimalYamlParser
-    {
-        internal class Mapping
-        {
-            private Dictionary<string, string> _lastEntry;
-
-            public Mapping()
-            {
-                Sequences = new List<Dictionary<string, string>>();
-            }
-
-            public List<Dictionary<string, string>> Sequences { get; }
-
-            public void BeginSequence()
-            {
-                _lastEntry = new Dictionary<string, string>();
-                Sequences.Add(_lastEntry);
-            }
-
-            public void AddToSequence(string key, string value)
-            {
-                _lastEntry[key] = value;
-            }
-        }
-
-        private readonly Dictionary<string, Mapping> _mappings = new Dictionary<string, Mapping>();
-
-        public MinimalYamlParser(string yamlString)
-        {
-            ReadIntoMappingModel(yamlString);
-        }
-
-        internal IDictionary<string, Mapping> Mappings => _mappings;
-
-        private void ReadIntoMappingModel(string yamlInputString)
-        {
-            // line splitting using various splitting characters
-            string[] lines = yamlInputString.Split(new[] { Environment.NewLine, "\r", "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-            int lineCount = 0;
-            Mapping activeMapping = null;
-
-            foreach (var line in lines)
-            {
-                lineCount++;
-                if (line.Trim().StartsWith("#")) //skipping comments
-                    continue;
-                if (line.Trim().Length == 0)
-                    continue;
-
-                //is this a new mapping entity
-                if (line[0] != ' ')
-                {
-                    int indexOfMappingColon = line.IndexOf(':');
-                    if (indexOfMappingColon == -1)
-                        throw new ArgumentException("YamlParsing: Expecting mapping entry to contain a ':', at line " + lineCount);
-                    string name = line.Substring(0, indexOfMappingColon).Trim();
-                    activeMapping = new Mapping();
-                    _mappings.Add(name, activeMapping);
-                    continue;
-                }
-
-                //reading scalar entries into the active mapping
-                if (activeMapping == null)
-                    throw new ArgumentException("YamlParsing: Expecting mapping entry to contain a ':', at line " + lineCount);
-
-                var seqLine = line.Trim();
-                if (seqLine[0] == '-')
-                {
-                    activeMapping.BeginSequence();
-                    seqLine = seqLine.Substring(1);
-                }
-
-                int indexOfColon = seqLine.IndexOf(':');
-                if (indexOfColon == -1)
-                    throw new ArgumentException("YamlParsing: Expecting scalar mapping entry to contain a ':', at line " + lineCount);
-
-                string key = seqLine.Substring(0, indexOfColon).Trim();
-                string value = ReadQuotedValue(seqLine.Substring(indexOfColon + 1).Trim());
-                activeMapping.AddToSequence(key, value);
-            }
-        }
-
-        private static string ReadQuotedValue(string value)
-        {
-            if (value.StartsWith("'") && value.EndsWith("'"))
-                return value.Substring(1, value.Length - 2);
-            if (value.StartsWith("\"") && value.EndsWith("\""))
-                return value.Substring(1, value.Length - 2);
-            return value;
-        }
-
-        public IEnumerable<Dictionary<string, string>> ReadMapping(string mappingName)
-        {
-            if (_mappings.TryGetValue(mappingName, out var mapping))
-            {
-                foreach (var s in mapping.Sequences)
-                {
-                    var temp = s;
-                    yield return temp;
-                }
-            }
-        }
-    }
-
 }

--- a/UAParser/UserAgent.cs
+++ b/UAParser/UserAgent.cs
@@ -1,0 +1,67 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser
+{
+    /// <summary>
+    /// Represents a user agent, commonly a browser
+    /// </summary>
+    public sealed class UserAgent
+    {
+        /// <summary>
+        /// Construct a UserAgent instance
+        /// </summary>
+        public UserAgent(string family, string major, string minor, string patch)
+        {
+            Family = family;
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+        }
+
+        /// <summary>
+        /// The family of user agent
+        /// </summary>
+        public string Family { get; }
+        /// <summary>
+        /// Major version of the user agent, if available
+        /// </summary>
+        public string Major { get; }
+        /// <summary>
+        /// Minor version of the user agent, if available
+        /// </summary>
+        public string Minor { get; }
+        /// <summary>
+        /// Patch version of the user agent, if available
+        /// </summary>
+        public string Patch { get; }
+
+        /// <summary>
+        /// The user agent as a readbale string
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var version = VersionString.Format(Major, Minor, Patch);
+            return Family + (!string.IsNullOrEmpty(version) ? " " + version : null);
+        }
+    }
+
+}

--- a/UAParser/VersionString.cs
+++ b/UAParser/VersionString.cs
@@ -1,0 +1,34 @@
+#region Apache License, Version 2.0
+//
+// Copyright 2014 Atif Aziz
+// Portions Copyright 2012 Søren Enemærke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+
+namespace UAParser
+{
+    using System;
+    using System.Linq;
+
+    internal static class VersionString
+    {
+        public static string Format(params string[] parts)
+        {
+            return string.Join(".", parts.Where(v => !String.IsNullOrEmpty(v)).ToArray());
+        }
+    }
+
+}


### PR DESCRIPTION
This idea for this PR is based on #60, but it just extracts all nested classes to their own files (`CTRL + .` and "Move to xx.cs"). this is common best pratice in the .NET world.
Also all files were formatted via `Edit`->`Advanced`->`Format Document`.

Hopefully it makes it easier to add the performance improvements from #60 and future ones.