### PR TITLE
Cache the default parser instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Usage:
 
   string uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3";
 
-  // get a parser with the embedded regex patterns
+  // Create the parser once and reuse it. Parser construction parses the embedded
+  // yaml and builds regex structures, so avoid creating a parser per request.
   var uaParser = Parser.GetDefault();
 
   // get a parser using externally supplied yaml definitions
@@ -52,6 +53,17 @@ Usage:
 
   Console.WriteLine(c.Device.Family);    // => "iPhone"
 ```
+
+In ASP.NET Core, register the parser as a singleton and inject it where needed:
+
+```csharp
+using UAParser;
+
+builder.Services.AddSingleton(_ => Parser.GetDefault());
+```
+
+If you construct a parser with `Parser.FromYaml(...)` or `Parser.GetDefault(new ParserOptions { ... })`,
+cache and reuse that instance as well instead of creating it on each request.
 
 Authors:
 -------

--- a/UAParser.Tests/ParserTests.cs
+++ b/UAParser.Tests/ParserTests.cs
@@ -18,6 +18,24 @@ namespace UAParser.Tests
         }
 
         [Fact]
+        public void parameterless_get_default_returns_cached_parser()
+        {
+            Parser first = Parser.GetDefault();
+            Parser second = Parser.GetDefault();
+
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void get_default_with_options_returns_a_new_parser()
+        {
+            Parser cachedDefault = Parser.GetDefault();
+            Parser configured = Parser.GetDefault(new ParserOptions());
+
+            Assert.NotSame(cachedDefault, configured);
+        }
+
+        [Fact]
         public void can_get_parser_from_input()
         {
             string yamlContent = this.GetTestResources("UAParser.Tests.Regexes.regexes.yaml");

--- a/UAParser/UAParser.cs
+++ b/UAParser/UAParser.cs
@@ -287,6 +287,9 @@ namespace UAParser
         /// </summary>
         public const string Other = "Other";
 
+        private static readonly object DefaultParserLock = new object();
+        private static Parser _defaultParser;
+
         private readonly Func<string, OS> _osParser;
         private readonly Func<string, Device> _deviceParser;
         private readonly Func<string, UserAgent> _userAgentParser;
@@ -308,6 +311,10 @@ namespace UAParser
         /// <summary>
         /// Returns a <see cref="Parser"/> instance based on the regex definitions in a yaml string
         /// </summary>
+        /// <remarks>
+        /// Parser construction is relatively expensive because the yaml definitions must be parsed and
+        /// the regex structures must be built. Reuse the returned parser instead of creating one per request.
+        /// </remarks>
         /// <param name="yaml">a string containing yaml definitions of reg-ex</param>
         /// <param name="parserOptions">specifies the options for the parser</param>
         /// <returns>A <see cref="Parser"/> instance parsing user agent strings based on the regexes defined in the yaml string</returns>
@@ -318,11 +325,33 @@ namespace UAParser
 
         /// <summary>
         /// Returns a <see cref="Parser"/> instance based on the embedded regex definitions.
-        /// <remarks>The embedded regex definitions may be outdated. Consider passing in external yaml definitions using <see cref="Parser.FromYaml"/></remarks>
         /// </summary>
+        /// <remarks>
+        /// Parser construction is relatively expensive because the embedded yaml definitions must be parsed and
+        /// the regex structures must be built. Reuse the returned parser instead of creating one per request.
+        /// The parameterless overload returns a cached default parser for this reason. The embedded regex definitions
+        /// may be outdated, so consider passing in external yaml definitions using <see cref="Parser.FromYaml"/>.
+        /// </remarks>
         /// <param name="parserOptions">specifies the options for the parser</param>
         /// <returns></returns>
         public static Parser GetDefault(ParserOptions parserOptions = null)
+        {
+            if (parserOptions != null)
+                return CreateDefaultParser(parserOptions);
+
+            if (_defaultParser != null)
+                return _defaultParser;
+
+            lock (DefaultParserLock)
+            {
+                if (_defaultParser == null)
+                    _defaultParser = CreateDefaultParser(null);
+            }
+
+            return _defaultParser;
+        }
+
+        private static Parser CreateDefaultParser(ParserOptions parserOptions)
         {
             using (var stream = typeof(Parser)
 #if INTROSPECTION_EXTENSIONS


### PR DESCRIPTION
# Summary 

Cache the parameterless Parser.GetDefault() instance so callers can safely reuse the embedded default parser without rebuilding it on every call.

This change keeps Parser.GetDefault(new ParserOptions(...)) and Parser.FromYaml(...) creating new parser instances, while making the common default path inexpensive after first use.

## Problem
Parser.GetDefault() currently rebuilds the parser every time it is called by:

* Reading the embedded regexes.yaml
* Parsing the yaml
* Constructing regex and parser structures

This is functionally correct, but it becomes expensive when used in hot paths. In our case, profiling showed repeated parser construction contributing significant memory allocation pressure.

## Changes

* Cache the parameterless Parser.GetDefault() instance behind a thread-safe static lock
* Preserve existing behaviour for Parser.GetDefault(parserOptions) by continuing to create a fresh parser when options are supplied
* Update XML documentation to clarify that parser construction is expensive and parser instances should be reused
* Update the README to recommend one-time construction / singleton registration
* Add tests covering cached default behavior and non-cached option-based behavior

## Why this approach
The common GetDefault() path is the one most consumers will use, and it already relies on embedded static regex definitions. Reusing a single instance makes that path safe for repeated use without requiring every downstream consumer to discover and implement their own caching layer.

At the same time, the options overload still returns a fresh parser so callers do not lose option-specific behaviour.
